### PR TITLE
Add runners for macOS and Windows

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.12"]
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: ["3.10", "3.12"]
+        os: ["ubuntu-latest", "windows-latest"]
 
+    runs-on: ${{ matrix.os }}
+    
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Updated the [runner](https://github.com/Foggalong/RobustOCS/actions/workflows/check-build.yml) which checks the package is building and spitting out sensible numbers so that it will also do that on Windows and macOS.