### PR TITLE
Integrate Pedigree Submodule

### DIFF
--- a/robustocs/__init__.py
+++ b/robustocs/__init__.py
@@ -6,6 +6,7 @@ for internal data structures, and depends on Gurobi or HiGHS for its solvers.
 """
 
 from .loaders import *
+from .pedigree import *
 from .solvers import *
 from .utils import *
 
@@ -15,7 +16,9 @@ __version__ = "0.1.0"
 # controls what's imported on `from robustocs import *`
 __all__ = [
     # from loaders.py
-    "load_ped", "makeA", "load_problem",
+    "load_ped", "load_problem",
+    # from pedigree.py
+    "makeA", "make_invA",
     # from solvers.py
     "gurobi_standard_genetics", "gurobi_robust_genetics",
     "gurobi_robust_genetics_sqp", "gurobi_robust_genetics_conic",

--- a/robustocs/__init__.py
+++ b/robustocs/__init__.py
@@ -3,12 +3,20 @@
 RobustOCS provides functions for loading and solving robust genetic selection
 problems. It uses file structures from the AlphaGenes family, NumPy and SciPy
 for internal data structures, and depends on Gurobi or HiGHS for its solvers.
+
+Documentation is available in the docstrings and online at
+https://github.com/Foggalong/RobustOCS/wiki
 """
 
-from .loaders import *
-from .pedigree import *
-from .solvers import *
-from .utils import *
+from .loaders import load_ped, load_problem
+from .pedigree import makeA, make_invA
+from .solvers import (
+    gurobi_standard_genetics, gurobi_robust_genetics,
+    gurobi_robust_genetics_sqp, gurobi_robust_genetics_conic,
+    highs_standard_genetics, highs_robust_genetics,
+    highs_robust_genetics_sqp
+)
+from .utils import print_compare_solutions, check_uncertainty_constraint
 
 __author__ = "Josh Fogg"
 __version__ = "0.1.0"

--- a/robustocs/loaders.py
+++ b/robustocs/loaders.py
@@ -8,7 +8,9 @@ functions define the appropriate methods for loading those in correctly.
 import numpy as np          # defines matrix structures
 import numpy.typing as npt  # variable typing definitions for NumPy
 from scipy import sparse    # used for sparse matrix format
-from pedigree import makeA  # local import for processing pedigree data
+
+# local imports for processing pedigree data
+from .pedigree import makeA
 
 # controls what's imported on `from robustocs.loaders import *`
 __all__ = ["load_ped", "load_problem"]

--- a/robustocs/loaders.py
+++ b/robustocs/loaders.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Loading in Genetics Data
+"""Loading in OCS Problem Data
 
-Genetics data could be presented to our solvers in multiple formats, these
-functions define the appropriate methods for loading those in correctly.
+Genetics data could be presented to our solvers in multiple formats, so the
+functions in `loaders` define the appropriate methods for loading those into
+Python correctly.
+
+Documentation is available in the docstrings and online at
+https://github.com/Foggalong/RobustOCS/wiki
 """
 
 import numpy as np          # defines matrix structures

--- a/robustocs/loaders.py
+++ b/robustocs/loaders.py
@@ -8,9 +8,10 @@ functions define the appropriate methods for loading those in correctly.
 import numpy as np          # defines matrix structures
 import numpy.typing as npt  # variable typing definitions for NumPy
 from scipy import sparse    # used for sparse matrix format
+from pedigree import makeA  # local import for processing pedigree data
 
 # controls what's imported on `from robustocs.loaders import *`
-__all__ = ["load_ped", "makeA", "load_problem"]
+__all__ = ["load_ped", "load_problem"]
 
 
 # DATA LOADERS
@@ -223,51 +224,9 @@ def load_ped(filename: str) -> dict[int, list[int]]:
         file.readline()
         # create a list of int lists from each line (dropping optional labels)
         data = [[int(x) for x in line.split(",")[0:3]] for line in file]
-    # convert this list of lists into a dictionary
-    ped = {entry[0]: entry[1:3] for entry in data}
 
-    return ped
-
-
-# MATRIX GENERATORS
-# Utility functions for generating matrices from pedigree data.
-
-def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
-    """
-    Constructs Wright's Numerator Relationship Matrix (WNRM) from a given
-    pedigree structure.
-
-    Parameters
-    ----------
-    pedigree : dict
-        Pedigree structure in `{int: [int, int]}` dictionary format, such
-        as that returned from `load_ped`.
-
-    Returns
-    -------
-    ndarray
-        Wright's Numerator Relationship Matrix.
-    """
-
-    m = len(pedigree)
-    # preallocate memory for A
-    A = np.zeros((m, m), dtype=np.floating)
-
-    # iterate over rows
-    for i in range(0, m):
-        # save parent indexes: pedigrees indexed from 1, Python from 0
-        p = pedigree[i+1][0]-1
-        q = pedigree[i+1][1]-1
-        # iterate over columns sub-diagonal
-        for j in range(0, i):
-            # calculate sub-diagonal entries
-            A[i, j] = 0.5*(A[j, p] + A[j, q])
-            # populate sup-diagonal (symmetric)
-            A[j, i] = A[i, j]
-        # calculate diagonal entries
-        A[i, i] = 1 + 0.5*A[p, q]
-
-    return A
+    # convert the list of lists into a dictionary on return
+    return {entry[0]: entry[1:3] for entry in data}
 
 
 # PROBLEM LOADERS

--- a/robustocs/pedigree.py
+++ b/robustocs/pedigree.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""Working with Pedigree Data
+
+TODO update this docstring.
+Script which reads in a pedigree datafile and returns Wright's Numerator
+Relationship Matrix for that pedigree structure.
+"""
+
+import numpy as np                  # standard NLA package
+from numpy import linalg as nla     # all eigenvalues
+
+
+def sparsity(matrix):
+    """Quick function which returns the sparsity of a matrix"""
+    return np.count_nonzero(matrix)/np.product(matrix.shape)
+
+
+def maxEig(matrix, max_iterations, tolerance):
+    """
+    Takes a matrix (A), a maximum number of iterations (max_it), and
+    a tolerance (tol) and does at most that number of iterations of
+    the power method to find the largest eigenvalue of the matrix
+    within that tolerance.
+    """
+
+    x = np.transpose(np.sum(matrix, axis=1))
+    x = x/np.nla.norm(x)
+    lam = 0
+    # perform power method for set number of iterations
+    for i in range(1, max_iterations):
+        Ax = np.matmul(A, x)
+        lambda_new = np.matmul(np.transpose(x), np.matmul(A, x))/np.dot(x, x)
+        # finding largest so lambda^(i) > lambda^(i-1)
+        if (lambda_new-lam) < tolerance:
+            return lam
+        lam = lambda_new
+        x = Ax/nla.norm(x)
+    # reached iteration limit, return whatever lambda we have
+    return lam
+
+
+def readPed(filename):
+    """
+    Function for reading *.ped files to a dictionary. Takes the file name
+    as a string input and returns the pedigree structure as a dictionary.
+    """
+    with open(filename, "r") as file:
+        # first line of *.ped lists the headers; skip
+        file.readline()
+        # create a list of int lists from each line (dropping optional labels)
+        data = [[int(x) for x in line.split(",")[0:3]] for line in file]
+    # convert this list of lists into a dictionary
+    ped = {entry[0]: entry[1:3] for entry in data}
+    return(ped)
+
+
+def makeA(pedigree):
+    """
+    Construct Wright's Numerator Relationship Matrix from a given pedigree
+    structure. Takes the pedigree as a dictionary input and returns the
+    matrix as output.
+    """
+    m = len(pedigree)
+    A = np.zeros((m, m))
+
+    # iterate over rows
+    for i in range(0, m):
+        # save parent indexes: pedigrees indexed from 1, Python from 0
+        p = pedigree[i+1][0]-1
+        q = pedigree[i+1][1]-1
+        # iterate over columns sub-diagonal
+        for j in range(0, i):
+            # calculate sub-diagonal entries
+            A[i, j] = 0.5*(A[j, p] + A[j, q])
+            # populate sup-diagonal (symmetric)
+            A[j, i] = A[i, j]
+        # calculate diagonal entries
+        A[i, i] = 1 + 0.5*A[p, q]
+
+    return(A)
+
+
+def makeL(pedigree):
+    """
+    Construct the Cholesky factor L of Wright's Numerator Relationship Matrix
+    from a given pedigree structure. Takes the pedigree as a dictionary input
+    and returns the matrix L (in A = L'L) as output.
+    """
+    m = len(pedigree)
+    L = np.zeros((m, m))
+
+    # iterate over rows
+    for i in range(0, m):
+        # save parent indexes: pedigrees indexed from 1, Python from 0
+        p = pedigree[i+1][0]-1
+        q = pedigree[i+1][1]-1
+
+        # case where both parents are known; p < q bny *.ped convention
+        if p >= 0 and q >= 0:
+            for j in range(0, p+1):
+                L[i, j] = 0.5*(L[p, j] + L[q, j])
+            for j in range(p+1, q+1):
+                L[i, j] = 0.5*L[q, j]
+            # and L[i,j] = 0 for j = (q+1):i
+
+            # compute the diagonal
+            s = 1
+            for j in range(0, p+1):
+                s += 0.5*L[p, j]*L[q, j]
+            for j in range(0, q+1):
+                s -= L[i, j]**2
+            L[i, i] = s**0.5
+
+        # case where one parent is known; p by *.ped convention
+        elif p >= 0:  # and q = 0
+            for j in range(0, p+1):
+                L[i, j] = 0.5*L[p, j]
+            # and L[i,j] = 0 for j = (q+1):i
+
+            # compute the diagonal
+            s = 1
+            for j in range(0, p+1):
+                s -= L[i, j]**2
+            L[i, i] = s**0.5
+
+        else:
+            for j in range(0, i):
+                L[i, j] = 0
+            L[i, i] = 1
+
+    return(L)
+
+
+def make_invD2(pedigree):
+    """
+    Construct the inverse of the D^2 factor from the Henderson (1976)
+    decomposition of a WNRM. Takes the pedigree as a dictionary input
+    and returns the inverse of matrix D^2 (in A = L'L = T'DDT) as output.
+    """
+    m = len(pedigree)
+    L = makeL(pedigree)
+    invD2 = np.zeros((m, m))  # TODO find a way to store diagonal matrices
+
+    # iterate over rows
+    for i in range(0, m):
+        invD2[i, i] = 1/(L[i, i]**2)
+
+    return(invD2)
+
+
+def make_invT(pedigree):
+    """
+    Construct the inverse of the D factor from the Henderson (1976)
+    decomposition of a WNRM. Takes the pedigree as a dictionary input
+    and returns the inverse of matrix D (in A = L'L = T'DDT) as output.
+    """
+    m = len(pedigree)
+    invT = np.zeros((m, m))
+
+    for i in range(0, m):
+        # label parents p & q
+        p = pedigree[i+1][0]-1
+        q = pedigree[i+1][1]-1
+        # set columns corresponding to known parents to -0.5
+        if p >= 0:
+            invT[i, p] = -0.5
+        if q >= 0:
+            invT[i, q] = -0.5
+        # T^-1 has 1s on the diagonal
+        invT[i, i] = 1
+
+    return(invT)
+
+
+def make_invA(pedigree):
+    """
+    Compute the inverse of A using a shortcut which exploits
+    of its T and D decomposition, detailed in Henderson (1976).
+    Takes the pedigree as a dictionary input and returns the
+    inverse as matrix output.
+    """
+    m = len(pedigree)
+    B = make_invD2(ped)
+    invA = B
+
+    for i in range(0, m):
+        # label parents p & q
+        p = pedigree[i+1][0]-1
+        q = pedigree[i+1][1]-1
+
+        # case where both both parents are known
+        if p >= 0 and q >= 0:
+            x = -0.5*B[i, i]
+            y = 0.25*B[i, i]
+            invA[p, i] += x
+            invA[i, p] += x
+            invA[q, i] += x
+            invA[i, q] += x
+            invA[p, p] += y
+            invA[p, q] += y
+            invA[q, p] += y
+            invA[q, q] += y
+
+        # case where one parent is known; p by *.ped convention
+        elif p >= 0:
+            x = -0.5*B[i, i]
+            invA[p, i] += x
+            invA[i, p] += x
+            invA[p, p] += 0.25*B[i, i]
+
+    return(invA)
+
+
+def make_invA_decomposition(pedigree):
+    """
+    Calculate the inverse of A using its T and D decomposition
+    factors from Henderson (1976). Takes the pedigree as a
+    dictionary input and returns the inverse as matrix output.
+    """
+    invD2 = make_invD2(ped)
+    invT = make_invT(ped)
+
+    # computing A^-1 = (T^-1)' * (D^2)^-1 * T^-1 in full
+    invA = np.matmul(invT.transpose(), np.matmul(invD2, invT))
+    return(invA)

--- a/robustocs/pedigree.py
+++ b/robustocs/pedigree.py
@@ -6,8 +6,8 @@ Script which reads in a pedigree datafile and returns Wright's Numerator
 Relationship Matrix for that pedigree structure.
 """
 
-import numpy as np                  # standard NLA package
-from numpy import linalg as nla     # all eigenvalues
+import numpy as np          # defines matrix structures
+import numpy.typing as npt  # variable typing definitions for NumPy
 
 
 def maxEig(matrix, max_iterations, tolerance):
@@ -33,30 +33,26 @@ def maxEig(matrix, max_iterations, tolerance):
     # reached iteration limit, return whatever lambda we have
     return lam
 
+def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
+    """
+    Constructs Wright's Numerator Relationship Matrix (WNRM) from a given
+    pedigree structure.
 
-def readPed(filename):
-    """
-    Function for reading *.ped files to a dictionary. Takes the file name
-    as a string input and returns the pedigree structure as a dictionary.
-    """
-    with open(filename, "r") as file:
-        # first line of *.ped lists the headers; skip
-        file.readline()
-        # create a list of int lists from each line (dropping optional labels)
-        data = [[int(x) for x in line.split(",")[0:3]] for line in file]
-    # convert this list of lists into a dictionary
-    ped = {entry[0]: entry[1:3] for entry in data}
-    return(ped)
+    Parameters
+    ----------
+    pedigree : dict
+        Pedigree structure in `{int: [int, int]}` dictionary format, such
+        as that returned from `load_ped`.
 
+    Returns
+    -------
+    ndarray
+        Wright's Numerator Relationship Matrix.
+    """
 
-def makeA(pedigree):
-    """
-    Construct Wright's Numerator Relationship Matrix from a given pedigree
-    structure. Takes the pedigree as a dictionary input and returns the
-    matrix as output.
-    """
     m = len(pedigree)
-    A = np.zeros((m, m))
+    # preallocate memory for A
+    A = np.zeros((m, m), dtype=np.floating)
 
     # iterate over rows
     for i in range(0, m):
@@ -72,7 +68,7 @@ def makeA(pedigree):
         # calculate diagonal entries
         A[i, i] = 1 + 0.5*A[p, q]
 
-    return(A)
+    return A
 
 
 def makeL(pedigree):

--- a/robustocs/pedigree.py
+++ b/robustocs/pedigree.py
@@ -9,6 +9,8 @@ Relationship Matrix for that pedigree structure.
 import numpy as np          # defines matrix structures
 import numpy.typing as npt  # variable typing definitions for NumPy
 
+__all__ = ["makeA", "make_invA"]
+
 
 def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
@@ -27,15 +29,15 @@ def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
         Wright's Numerator Relationship Matrix.
     """
 
-    m = len(pedigree)
+    m: int = len(pedigree)
     # preallocate memory for A
-    A = np.zeros((m, m), dtype=np.floating)
+    A: npt.NDArray[np.floating] = np.zeros((m, m), dtype=np.floating)
 
     # iterate over rows
     for i in range(0, m):
         # save parent indexes: pedigrees indexed from 1, Python from 0
-        p = pedigree[i+1][0]-1
-        q = pedigree[i+1][1]-1
+        p: int = pedigree[i+1][0]-1
+        q: int = pedigree[i+1][1]-1
         # iterate over columns sub-diagonal
         for j in range(0, i):
             # calculate sub-diagonal entries
@@ -48,20 +50,22 @@ def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     return A
 
 
-def makeL(pedigree):
+def makeL(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
     Construct the Cholesky factor L of Wright's Numerator Relationship Matrix
     from a given pedigree structure. Takes the pedigree as a dictionary input
     and returns the matrix L (in A = L'L) as output.
+    # TODO update the docstring to the new standard
     """
-    m = len(pedigree)
-    L = np.zeros((m, m))
+
+    m: int = len(pedigree)
+    L: npt.NDArray[np.floating] = np.zeros((m, m), dtype=np.floating)
 
     # iterate over rows
     for i in range(0, m):
         # save parent indexes: pedigrees indexed from 1, Python from 0
-        p = pedigree[i+1][0]-1
-        q = pedigree[i+1][1]-1
+        p: int = pedigree[i+1][0]-1
+        q: int = pedigree[i+1][1]-1
 
         # case where both parents are known; p < q bny *.ped convention
         if p >= 0 and q >= 0:
@@ -72,7 +76,7 @@ def makeL(pedigree):
             # and L[i,j] = 0 for j = (q+1):i
 
             # compute the diagonal
-            s = 1
+            s: float = 1
             for j in range(0, p+1):
                 s += 0.5*L[p, j]*L[q, j]
             for j in range(0, q+1):
@@ -86,7 +90,7 @@ def makeL(pedigree):
             # and L[i,j] = 0 for j = (q+1):i
 
             # compute the diagonal
-            s = 1
+            s: float = 1
             for j in range(0, p+1):
                 s -= L[i, j]**2
             L[i, i] = s**0.5
@@ -96,39 +100,44 @@ def makeL(pedigree):
                 L[i, j] = 0
             L[i, i] = 1
 
-    return(L)
+    return L
 
 
-def make_invD2(pedigree):
+def make_invD2(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
     Construct the inverse of the D^2 factor from the Henderson (1976)
     decomposition of a WNRM. Takes the pedigree as a dictionary input
     and returns the inverse of matrix D^2 (in A = L'L = T'DDT) as output.
+    # TODO update the docstring to the new standard
     """
-    m = len(pedigree)
-    L = makeL(pedigree)
-    invD2 = np.zeros((m, m))  # TODO find a way to store diagonal matrices
+
+    m: int = len(pedigree)
+    L: npt.NDArray[np.floating] = makeL(pedigree)
+    # TODO find a better way to work with diagonal matrices
+    invD2: npt.NDArray[np.floating] = np.zeros((m, m), dtype=np.floating)
 
     # iterate over rows
     for i in range(0, m):
         invD2[i, i] = 1/(L[i, i]**2)
 
-    return(invD2)
+    return invD2
 
 
-def make_invT(pedigree):
+def make_invT(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
     Construct the inverse of the D factor from the Henderson (1976)
     decomposition of a WNRM. Takes the pedigree as a dictionary input
     and returns the inverse of matrix D (in A = L'L = T'DDT) as output.
+    # TODO update the docstring to the new standard
     """
-    m = len(pedigree)
-    invT = np.zeros((m, m))
+
+    m: int = len(pedigree)
+    invT: npt.NDArray[np.floating] = np.zeros((m, m), dtype=np.floating)
 
     for i in range(0, m):
         # label parents p & q
-        p = pedigree[i+1][0]-1
-        q = pedigree[i+1][1]-1
+        p: int = pedigree[i+1][0]-1
+        q: int = pedigree[i+1][1]-1
         # set columns corresponding to known parents to -0.5
         if p >= 0:
             invT[i, p] = -0.5
@@ -137,29 +146,31 @@ def make_invT(pedigree):
         # T^-1 has 1s on the diagonal
         invT[i, i] = 1
 
-    return(invT)
+    return invT
 
 
-def make_invA(pedigree):
+def make_invA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
     Compute the inverse of A using a shortcut which exploits
     of its T and D decomposition, detailed in Henderson (1976).
     Takes the pedigree as a dictionary input and returns the
     inverse as matrix output.
+    # TODO update the docstring to the new standard
     """
-    m = len(pedigree)
-    B = make_invD2(ped)
+
+    m: int = len(pedigree)
+    B: npt.NDArray[np.floating] = make_invD2(pedigree)
     invA = B
 
     for i in range(0, m):
         # label parents p & q
-        p = pedigree[i+1][0]-1
-        q = pedigree[i+1][1]-1
+        p: int = pedigree[i+1][0]-1
+        q: int = pedigree[i+1][1]-1
 
         # case where both both parents are known
         if p >= 0 and q >= 0:
-            x = -0.5*B[i, i]
-            y = 0.25*B[i, i]
+            x: float = -0.5*B[i, i]
+            y: float = 0.25*B[i, i]
             invA[p, i] += x
             invA[i, p] += x
             invA[q, i] += x
@@ -171,23 +182,25 @@ def make_invA(pedigree):
 
         # case where one parent is known; p by *.ped convention
         elif p >= 0:
-            x = -0.5*B[i, i]
+            x: float = -0.5*B[i, i]
             invA[p, i] += x
             invA[i, p] += x
             invA[p, p] += 0.25*B[i, i]
 
-    return(invA)
+    return invA
 
 
-def make_invA_decomposition(pedigree):
+def make_invA_decomposition(
+    pedigree: dict[int, list[int]]
+) -> npt.NDArray[np.floating]:
     """
     Calculate the inverse of A using its T and D decomposition
     factors from Henderson (1976). Takes the pedigree as a
     dictionary input and returns the inverse as matrix output.
+    # TODO update the docstring to the new standard
     """
-    invD2 = make_invD2(ped)
-    invT = make_invT(ped)
+    invD2: npt.NDArray[np.floating] = make_invD2(pedigree)
+    invT: npt.NDArray[np.floating] = make_invT(pedigree)
 
     # computing A^-1 = (T^-1)' * (D^2)^-1 * T^-1 in full
-    invA = np.matmul(invT.transpose(), np.matmul(invD2, invT))
-    return(invA)
+    return np.matmul(invT.transpose(), np.matmul(invD2, invT))

--- a/robustocs/pedigree.py
+++ b/robustocs/pedigree.py
@@ -10,29 +10,6 @@ import numpy as np          # defines matrix structures
 import numpy.typing as npt  # variable typing definitions for NumPy
 
 
-def maxEig(matrix, max_iterations, tolerance):
-    """
-    Takes a matrix (A), a maximum number of iterations (max_it), and
-    a tolerance (tol) and does at most that number of iterations of
-    the power method to find the largest eigenvalue of the matrix
-    within that tolerance.
-    """
-
-    x = np.transpose(np.sum(matrix, axis=1))
-    x = x/np.nla.norm(x)
-    lam = 0
-    # perform power method for set number of iterations
-    for i in range(1, max_iterations):
-        Ax = np.matmul(A, x)
-        lambda_new = np.matmul(np.transpose(x), np.matmul(A, x))/np.dot(x, x)
-        # finding largest so lambda^(i) > lambda^(i-1)
-        if (lambda_new-lam) < tolerance:
-            return lam
-        lam = lambda_new
-        x = Ax/nla.norm(x)
-    # reached iteration limit, return whatever lambda we have
-    return lam
-
 def makeA(pedigree: dict[int, list[int]]) -> npt.NDArray[np.floating]:
     """
     Constructs Wright's Numerator Relationship Matrix (WNRM) from a given

--- a/robustocs/pedigree.py
+++ b/robustocs/pedigree.py
@@ -10,11 +10,6 @@ import numpy as np                  # standard NLA package
 from numpy import linalg as nla     # all eigenvalues
 
 
-def sparsity(matrix):
-    """Quick function which returns the sparsity of a matrix"""
-    return np.count_nonzero(matrix)/np.product(matrix.shape)
-
-
 def maxEig(matrix, max_iterations, tolerance):
     """
     Takes a matrix (A), a maximum number of iterations (max_it), and

--- a/robustocs/solvers.py
+++ b/robustocs/solvers.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Defining Solvers
 
-With the problems properly loaded into Numpy, this section contains functions
-for solving those under various formulations and methods.
+With an optimal contribution selection problems properly loaded into Python,
+`solvers` contains functions for solving those under various formulations and
+methods.
+
+Documentation is available in the docstrings and online at
+https://github.com/Foggalong/RobustOCS/wiki
 """
 
 import numpy as np          # defines matrix structures

--- a/robustocs/utils.py
+++ b/robustocs/utils.py
@@ -244,6 +244,37 @@ def solveROCS(
 # ANALYSIS UTILITIES
 # These functions are useful for analysing particular solutions
 
+
+def sparsity(matrix: npt.ArrayLike, explicit_as_nz: bool = True) -> float:
+    """
+    Shortcut function which computes the sparsity of a matrix.
+
+    Parameters
+    ----------
+    matrix : ArrayLike
+        Any matrix or matrix-like object. Does not have to be square.
+    explicit_as_nz : bool, optional
+        If the matrix is not an `spmatrix` object, this will be ignored. If
+        it is and this parameter is True sparsity will be computed treating
+        explicit zeros as non-zeros, and of False treating them as zeros.
+        Default value is `True`.
+
+    Returns
+    -------
+    float
+        The sparsity of the matrix, i.e. the number of non-zero entries
+        divided by the number of entries total.
+    """
+
+    # spmatrix objects have attributes and methods for number of non-zeros
+    if isinstance(matrix, sparse.spmatrix):
+        nnz: int = matrix.nnz if explicit_as_nz else matrix.count_nonzero()
+    else:
+        nnz: int = np.count_nonzero(matrix)
+
+    return nnz / np.prod(matrix.shape)
+
+
 def expected_genetic_merit(w: npt.ArrayLike, mu: npt.ArrayLike) -> np.floating:
     """
     Shortcut function for computing the expected genetic merit (w'μ) of a

--- a/robustocs/utils.py
+++ b/robustocs/utils.py
@@ -104,8 +104,7 @@ def solveROCS(
         matrix or a sparse one. Default value is `False` (i.e. as dense).
     time_limit : float, optional
         Maximum amount of time in seconds to give the underlying solver to find
-        a solution. If using HiGHS this may overrun: see issue #16. Default
-        value is `None`, i.e. no time limit.
+        a solution. Default value is `None`, i.e. no time limit.
     max_iterations : int, optional
         Maximum number of iterations that can be taken in solving the robust
         problem using SQP. This is specific to robust optimization and will be

--- a/robustocs/utils.py
+++ b/robustocs/utils.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 """Utilities
 
-This file contains additional utilities, such as for printing and comparing
-portfolios produced by the solvers.
+In `utils` we define additional utilities to make working with RobustOCS
+easier, such as for printing and comparing different solutions.
+
+Documentation is available in the docstrings and online at
+https://github.com/Foggalong/RobustOCS/wiki
 """
 
 import math                 # used for math.sqrt


### PR DESCRIPTION
In September 2020 I wrote a very basic module/script for handling pedigree data as part of another project. Some of these were already integrated here so ROCS can solve problems from `.ped` datafiles, but given it's already written I'm going to integrate most of that module so that we have the analysis tools as well.

This will involve breaking API changes for `load_ped` and `makeA` as used in isolation only. Use as part of core solver functions will continue to work as intended.