### PR TITLE
Make compatible with numpy 2.0. Update to require highspy 1.14 and numpy 1.26.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "robustocs"
 version = "0.2.2"
 dependencies = [
-    "numpy >= 1.21",
+    "numpy >= 1.26.4",
     "scipy >= 1.8.0",
     # NLP added in 11.0.0, NumPy 2.x support in this version
     "gurobipy >= 11.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robustocs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
     "numpy >= 1.21",
     "scipy >= 1.8.0",
     # NLP added in 11.0.0, NumPy 2.x support in this version
     "gurobipy >= 11.0.3",
     # HiGHS modelling language commands were added in this version 
-    "highspy >= 1.7.2",
+    "highspy >= 1.14",
 ]
 requires-python = ">= 3.10"
 authors = [

--- a/robustocs/loaders.py
+++ b/robustocs/loaders.py
@@ -154,8 +154,8 @@ def load_sparse_symmetric_matrix(filename: str, dimension: int, nnz: int,
 
 
 def load_sexes(filename: str, dimension: int) -> tuple[
-    npt.NDArray[np.unsignedinteger],
-    npt.NDArray[np.unsignedinteger],
+    npt.NDArray[np.uint64],
+    npt.NDArray[np.uint64],
     npt.NDArray[np.str_]
 ]:
     """
@@ -181,8 +181,8 @@ def load_sexes(filename: str, dimension: int) -> tuple[
     """
 
     # preallocate output vectors
-    sires = np.zeros((dimension,), dtype=np.unsignedinteger)
-    dams = np.zeros((dimension,), dtype=np.unsignedinteger)
+    sires = np.zeros((dimension,), dtype=np.uint64)
+    dams = np.zeros((dimension,), dtype=np.uint64)
     names = np.zeros((dimension,), dtype=np.str_)
 
     # index trackers
@@ -255,8 +255,8 @@ def load_problem(
     npt.NDArray[np.float64],
     npt.NDArray[np.float64] | sparse.spmatrix | None,
     int,
-    npt.NDArray[np.unsignedinteger] | None,
-    npt.NDArray[np.unsignedinteger] | None,
+    npt.NDArray[np.uint64] | None,
+    npt.NDArray[np.uint64] | None,
     npt.NDArray[np.str_] | None
 ]:
     """

--- a/robustocs/loaders.py
+++ b/robustocs/loaders.py
@@ -55,7 +55,7 @@ def count_sparse_nnz(filename: str) -> int:
 
 
 def load_symmetric_matrix(filename: str, dimension: int
-                          ) -> npt.NDArray[np.floating]:
+                          ) -> npt.NDArray[np.float64]:
     """
     Since NumPy doesn't have a stock way to load symmetric matrices stored in
     symmetric coordinate format, this adds one.
@@ -73,7 +73,7 @@ def load_symmetric_matrix(filename: str, dimension: int
         The matrix represented by the file.
     """
 
-    matrix = np.zeros([dimension, dimension], dtype=np.floating)
+    matrix = np.zeros([dimension, dimension], dtype=np.float64)
 
     with open(filename, 'r') as file:
         for line in file:
@@ -112,9 +112,9 @@ def load_sparse_symmetric_matrix(filename: str, dimension: int, nnz: int,
     """
 
     # preallocate storage arrays
-    rows: npt.NDArray[np.integer] = np.zeros(nnz, dtype=np.integer)
-    cols: npt.NDArray[np.integer] = np.zeros(nnz, dtype=np.integer)
-    vals: npt.NDArray[np.floating] = np.zeros(nnz, dtype=np.floating)
+    rows: npt.NDArray[np.int_] = np.zeros(nnz, dtype=np.int_)
+    cols: npt.NDArray[np.int_] = np.zeros(nnz, dtype=np.int_)
+    vals: npt.NDArray[np.float64] = np.zeros(nnz, dtype=np.float64)
 
     with open(filename, 'r') as file:
         index: int = 0
@@ -141,13 +141,13 @@ def load_sparse_symmetric_matrix(filename: str, dimension: int, nnz: int,
         return sparse.coo_matrix(
             (vals, (rows, cols)),
             shape=(dimension, dimension),
-            dtype=np.floating
+            dtype=np.float64
         )
     elif format == 'csr':
         return sparse.csr_matrix(
             (vals, (rows, cols)),
             shape=(dimension, dimension),
-            dtype=np.floating
+            dtype=np.float64
         )
     else:
         raise ValueError("Format must be 'coo' or 'csr'.")
@@ -251,9 +251,9 @@ def load_problem(
     pedigree: bool = False,
     issparse: bool = False
 ) -> tuple[
-    npt.NDArray[np.floating] | sparse.spmatrix,
-    npt.NDArray[np.floating],
-    npt.NDArray[np.floating] | sparse.spmatrix | None,
+    npt.NDArray[np.float64] | sparse.spmatrix,
+    npt.NDArray[np.float64],
+    npt.NDArray[np.float64] | sparse.spmatrix | None,
     int,
     npt.NDArray[np.unsignedinteger] | None,
     npt.NDArray[np.unsignedinteger] | None,
@@ -316,7 +316,7 @@ def load_problem(
         then the value is `None`.
     """
 
-    mu: npt.NDArray[np.floating] = np.loadtxt(mu_filename, dtype=np.floating)
+    mu: npt.NDArray[np.float64] = np.loadtxt(mu_filename, dtype=np.float64)
     # if dimension not specified, use `mu` which doesn't need preallocation
     if not dimension:
         assert isinstance(mu.size, int)  # catches mu being empty
@@ -340,14 +340,14 @@ def load_problem(
             )
         else:
             # if nnz_omega was defined, it's ignored as a parameter
-            omega: npt.NDArray[np.floating] = load_symmetric_matrix(
+            omega: npt.NDArray[np.float64] = load_symmetric_matrix(
                 omega_filename, dimension
             )
 
     # sigma can be stored as a pedigree or by coordinates and can be loaded to
     # SciPy's CSR or Numpy's dense format. Hence have four branches below.
     if pedigree:
-        sigma: npt.NDArray[np.floating] = makeA(load_ped(sigma_filename))
+        sigma: npt.NDArray[np.float64] = makeA(load_ped(sigma_filename))
         # HACK this loads the full matrix, then converts it down to sparse
         if issparse:
             sigma: sparse.spmatrix = sparse.coo_matrix(sigma)
@@ -361,7 +361,7 @@ def load_problem(
             )
         else:
             # if nnz_sigma was defined here, it's ignored as a parameter
-            sigma: npt.NDArray[np.floating] = load_symmetric_matrix(
+            sigma: npt.NDArray[np.float64] = load_symmetric_matrix(
                 sigma_filename, dimension
             )
 

--- a/robustocs/solvers.py
+++ b/robustocs/solvers.py
@@ -121,7 +121,7 @@ def gurobi_standard_genetics(
     )
 
     # set up the two sum-to-half constraints
-    M = np.zeros((2, dimension), dtype=np.bool)
+    M = np.zeros((2, dimension), dtype=bool)
     # define the M so that column i is [1;0] if i is a sire and [0;1] otherwise
     M[0, sires] = 1
     M[1, dams] = 1
@@ -251,7 +251,7 @@ def gurobi_robust_genetics_conic(
     )
 
     # set up the two sum-to-half constraints
-    M = np.zeros((2, dimension), dtype=np.bool)
+    M = np.zeros((2, dimension), dtype=bool)
     # define the M so that column i is [1;0] if i is a sire and [0;1] otherwise
     M[0, sires] = 1
     M[1, dams] = 1
@@ -393,7 +393,7 @@ def gurobi_robust_genetics_sqp(
     )
 
     # set up the two sum-to-half constraints
-    M = np.zeros((2, dimension), dtype=np.bool)
+    M = np.zeros((2, dimension), dtype=bool)
     # define the M so that column i is [1;0] if i is a sire and [0;1] otherwise
     M[0, sires] = 1
     M[1, dams] = 1
@@ -559,6 +559,7 @@ def highs_standard_genetics(
     model.lp_.col_upper_ = highs_bound_like(dimension, upper_bound)
 
     # define the quadratic term in the objective
+    model.hessian_.format_ = highspy.HessianFormat.kSquare
     model.hessian_.dim_ = dimension
     model.hessian_.start_ = sigma.indptr
     model.hessian_.index_ = sigma.indices
@@ -729,6 +730,7 @@ def highs_robust_genetics_sqp(
     model.lp_.col_upper_ = highs_bound_like(dimension, upper_bound)
 
     # define the quadratic term in the objective
+    model.hessian_.format_ = highspy.HessianFormat.kSquare
     model.hessian_.dim_ = dimension
     model.hessian_.start_ = sigma.indptr
     model.hessian_.index_ = sigma.indices

--- a/robustocs/solvers.py
+++ b/robustocs/solvers.py
@@ -30,18 +30,18 @@ __all__ = [
 
 
 def gurobi_standard_genetics(
-    sigma: npt.NDArray[np.floating] | sparse.spmatrix,
-    mu: npt.NDArray[np.floating],
+    sigma: npt.NDArray[np.float64] | sparse.spmatrix,
+    mu: npt.NDArray[np.float64],
     sires,  # type could be np.ndarray, sets[ints], lists[int], range, etc
     dams,   # type could be np.ndarray, sets[ints], lists[int], range, etc
     lam: float,  # cannot be called `lambda`, that's reserved in Python
     dimension: int,
-    upper_bound: npt.NDArray[np.floating] | float = 1.0,
-    lower_bound: npt.NDArray[np.floating] | float = 0.0,
+    upper_bound: npt.NDArray[np.float64] | float = 1.0,
+    lower_bound: npt.NDArray[np.float64] | float = 0.0,
     time_limit: float | None = None,
     model_output: str = '',
     debug: bool = False
-) -> tuple[npt.NDArray[np.floating], float]:
+) -> tuple[npt.NDArray[np.float64], float]:
     """
     Solve the standard genetic selection problem using Gurobi.
 
@@ -142,20 +142,20 @@ def gurobi_standard_genetics(
 
 
 def gurobi_robust_genetics_conic(
-    sigma: npt.NDArray[np.floating] | sparse.spmatrix,
-    mubar: npt.NDArray[np.floating],
-    omega: npt.NDArray[np.floating] | sparse.spmatrix,
+    sigma: npt.NDArray[np.float64] | sparse.spmatrix,
+    mubar: npt.NDArray[np.float64],
+    omega: npt.NDArray[np.float64] | sparse.spmatrix,
     sires,  # type could be np.ndarray, sets[ints], lists[int], range, etc
     dams,   # type could be np.ndarray, sets[ints], lists[int], range, etc
     lam: float,  # cannot be called `lambda`, that's reserved in Python
     kappa: float,
     dimension: int,
-    upper_bound: npt.NDArray[np.floating] | float = 1.0,
-    lower_bound: npt.NDArray[np.floating] | float = 0.0,
+    upper_bound: npt.NDArray[np.float64] | float = 1.0,
+    lower_bound: npt.NDArray[np.float64] | float = 0.0,
     time_limit: float | None = None,
     model_output: str = '',
     debug: bool = False
-) -> tuple[npt.NDArray[np.floating], float, float]:
+) -> tuple[npt.NDArray[np.float64], float, float]:
     """
     Solve the robust genetic selection problem using Gurobi.
 
@@ -256,7 +256,7 @@ def gurobi_robust_genetics_conic(
     M[0, sires] = 1
     M[1, dams] = 1
     # define the right hand side of the constraint Mx = m
-    m = np.full(2, 0.5, dtype=np.floating)
+    m = np.full(2, 0.5, dtype=np.float64)
     model.addConstr(M@w == m, name="sum-to-half")
 
     # conic constraint which comes from robust optimization
@@ -275,22 +275,22 @@ def gurobi_robust_genetics_conic(
 
 
 def gurobi_robust_genetics_sqp(
-    sigma: npt.NDArray[np.floating] | sparse.spmatrix,
-    mubar: npt.NDArray[np.floating],
-    omega: npt.NDArray[np.floating] | sparse.spmatrix,
+    sigma: npt.NDArray[np.float64] | sparse.spmatrix,
+    mubar: npt.NDArray[np.float64],
+    omega: npt.NDArray[np.float64] | sparse.spmatrix,
     sires,  # type could be np.ndarray, sets[ints], lists[int], range, etc
     dams,   # type could be np.ndarray, sets[ints], lists[int], range, etc
     lam: float,  # cannot be called `lambda`, that's reserved in Python
     kappa: float,
     dimension: int,
-    upper_bound: npt.NDArray[np.floating] | float = 1.0,
-    lower_bound: npt.NDArray[np.floating] | float = 0.0,
+    upper_bound: npt.NDArray[np.float64] | float = 1.0,
+    lower_bound: npt.NDArray[np.float64] | float = 0.0,
     time_limit: float | None = None,
     max_iterations: int = 1000,
     robust_gap_tol: float = 1e-7,
     model_output: str = '',
     debug: bool = False
-) -> tuple[npt.NDArray[np.floating], float, float]:
+) -> tuple[npt.NDArray[np.float64], float, float]:
     """
     Solve the robust genetic selection problem using SQP in Gurobi.
 
@@ -398,7 +398,7 @@ def gurobi_robust_genetics_sqp(
     M[0, sires] = 1
     M[1, dams] = 1
     # define the right hand side of the constraint Mx = m
-    m = np.full(2, 0.5, dtype=np.floating)
+    m = np.full(2, 0.5, dtype=np.float64)
     model.addConstr(M@w == m, name="sum-to-half")
 
     # optional controls to stop Gurobi taking too long
@@ -440,7 +440,7 @@ def gurobi_robust_genetics_sqp(
             print("No active constraints!")
 
         # z coefficient for the new constraint
-        w_star: npt.NDArray[np.floating] = np.array(w.X)
+        w_star: npt.NDArray[np.float64] = np.array(w.X)
         alpha: float = sqrt(w_star.transpose()@omega@w_star)
 
         # if gap between z and w'Omega w has converged, done
@@ -458,8 +458,8 @@ gurobi_robust_genetics = gurobi_robust_genetics_conic
 
 
 def highs_bound_like(dimension: int,
-                     value: float | list[float] | npt.NDArray[np.floating]
-                     ):  # BUG broke: npt.NDArray[np.floating] | list[float]
+                     value: float | list[float] | npt.NDArray[np.float64]
+                     ):  # BUG broke: npt.NDArray[np.float64] | list[float]
     """
     Helper function which allows HiGHS to interpret variable bounds specified
     either as a vector or a single floating point value. If `value` is an array
@@ -472,17 +472,17 @@ def highs_bound_like(dimension: int,
 
 def highs_standard_genetics(
     sigma: sparse.spmatrix,
-    mu: npt.NDArray[np.floating],
+    mu: npt.NDArray[np.float64],
     sires,  # type could be np.ndarray, sets[ints], lists[int], range, etc
     dams,   # type could be np.ndarray, sets[ints], lists[int], range, etc
     lam: float,  # cannot be called `lambda`, that's reserved in Python
     dimension: int,
-    upper_bound: npt.NDArray[np.floating] | list[float] | float = 1.0,
-    lower_bound: npt.NDArray[np.floating] | list[float] | float = 0.0,
+    upper_bound: npt.NDArray[np.float64] | list[float] | float = 1.0,
+    lower_bound: npt.NDArray[np.float64] | list[float] | float = 0.0,
     time_limit: float | None = None,
     model_output: str = '',
     debug: bool = False
-) -> tuple[npt.NDArray[np.floating], float]:
+) -> tuple[npt.NDArray[np.float64], float]:
     """
     Solve the standard genetic selection problem using HiGHS.
 
@@ -608,7 +608,7 @@ def highs_standard_genetics(
                            f"{mod_status}")
 
     # by default, col_value is a stock-Python list
-    solution: npt.NDArray[np.floating] = np.array(h.getSolution().col_value)
+    solution: npt.NDArray[np.float64] = np.array(h.getSolution().col_value)
     # we negated the objective function, so negate it back
     objective_value: float = -h.getInfo().objective_function_value
 
@@ -617,21 +617,21 @@ def highs_standard_genetics(
 
 def highs_robust_genetics_sqp(
     sigma: sparse.spmatrix,
-    mubar: npt.NDArray[np.floating],
-    omega: npt.NDArray[np.floating] | sparse.spmatrix,
+    mubar: npt.NDArray[np.float64],
+    omega: npt.NDArray[np.float64] | sparse.spmatrix,
     sires,  # type could be np.ndarray, sets[ints], lists[int], range, etc
     dams,   # type could be np.ndarray, sets[ints], lists[int], range, etc
     lam: float,  # cannot be called `lambda`, that's reserved in Python
     kappa: float,
     dimension: int,
-    upper_bound: npt.NDArray[np.floating] | list[float] | float = 1.0,
-    lower_bound: npt.NDArray[np.floating] | list[float] | float = 0.0,
+    upper_bound: npt.NDArray[np.float64] | list[float] | float = 1.0,
+    lower_bound: npt.NDArray[np.float64] | list[float] | float = 0.0,
     time_limit: float | None = None,
     max_iterations: int = 1000,
     robust_gap_tol: float = 1e-7,
     model_output: str = '',
     debug: bool = False
-) -> tuple[npt.NDArray[np.floating], float, float]:
+) -> tuple[npt.NDArray[np.float64], float, float]:
     """
     Solve the robust genetic selection problem using SQP in HiGHS.
 
@@ -804,7 +804,7 @@ def highs_robust_genetics_sqp(
 
         # by default, col_value is a stock-Python list
         solution: list[float] = h.getSolution().col_value
-        w_star: npt.NDArray[np.floating] = np.array(solution[:-1])
+        w_star: npt.NDArray[np.float64] = np.array(solution[:-1])
         z_star: float = solution[-1]
 
         # we negated the objective function, so negate it back
@@ -834,7 +834,7 @@ def highs_robust_genetics_sqp(
         # add a new plane to the approximation of the uncertainty cone
         num_nz: int = dimension + 1  # HACK assuming entirely dense
         index: range = range(dimension + 1)
-        value: npt.NDArray[np.floating] = np.append(-omega@w_star, alpha)
+        value: npt.NDArray[np.float64] = np.append(-omega@w_star, alpha)
         h.addRow(0, inf, num_nz, index, value)
 
     # final value of solution is the z value, return separately


### PR DESCRIPTION
To use highspy 1.14 requires the line Hessian format to be explicitly square

model.hessian_.format_ = highspy.HessianFormat.kSquare

Hence now require highspy 1.14 

Bool, float and integer type definitions were incompatible with numpy 2.0+, so have been changed. 

Now compatible with numpy 2.0, but back-compatible with last v1 (1.26.4). Unable to check earlier versions of numpy, so now requires 1.26.4